### PR TITLE
Annotated errors + normalizing syntax-error properties

### DIFF
--- a/errorify.js
+++ b/errorify.js
@@ -5,11 +5,19 @@ var through = require('through2');
 // https://github.com/sindresorhus/ansi-regex/blob/47fb974/index.js
 var ansiRegex = /(?:(?:\u001b\[)|\u009b)(?:(?:[0-9]{1,3})?(?:(?:;[0-9]{0,3})*)?[A-M|f-m])|\u001b[A-M]/g;
 
-var errorProps = ['stack', 'name', 'message', 'fileName', 'lineNumber', 'columnNumber'];
+var errorProps = [
+  'stack', 
+  'annotated', 
+  'name', 
+  'message', 
+  'fileName', 
+  'lineNumber', 'line',
+  'columnNumber', 'column'
+];
 
 function template(error) {
   /*eslint-env browser*/
-  console.error(error);
+  console.error(error.name, error);
   if (typeof document === 'undefined') return;
   if (!document.body) {
     document.addEventListener('DOMContentLoaded', print);
@@ -19,7 +27,7 @@ function template(error) {
   function print() {
     var pre = document.createElement('pre');
     pre.className = 'errorify';
-    pre.textContent = error.message || error;
+    pre.textContent = error.annotated || error.message || error;
     if (document.body.firstChild) {
       document.body.insertBefore(pre, document.body.firstChild);
     } else {
@@ -28,14 +36,18 @@ function template(error) {
   }
 }
 
-function replace(err_) {
-  var err = {};
+function replace(err) {
+  var result = {};
   errorProps.forEach(function(key) {
-    if (err_[key]) {
-      err[key] = String(err_[key]).replace(ansiRegex, '');
+    var val = err[key];
+    if (typeof val !== 'undefined') {
+      if (typeof val === 'number')
+        result[key] = val;
+      else
+        result[key] = String(val).replace(ansiRegex, '');
     }
   });
-  return '!' + template + '(' + JSON.stringify(err) + ')';
+  return '!' + template + '(' + JSON.stringify(result) + ')';
 }
 
 module.exports = function errorify(b, opts) {


### PR DESCRIPTION
#2 looks great with babelify, but still a bit sad with regular browserify, just showing `"Unexpected Token"` in the browser.

Looks like browserify/acorn uses [syntax-error](https://www.npmjs.com/package/syntax-error), which has `err.annotated` for pretty-printing. Further, it uses non-standard `err.line` and `err.column`.

This PR takes a stab at normalizing the result for babelify and regular old browserify. This way non-babelify users can get nice errors too:

![screen shot 2015-03-22 at 9 05 24 pm](https://cloud.githubusercontent.com/assets/1383811/6772539/34267948-d0d7-11e4-86f6-a46c344ea62e.png)
