### PR TITLE
Create `onError` hook for custom logging and notifications 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ b.plugin(errorify, /* errorify options */);
 
 * `replacer` _(optional)_ is a function that takes an error as its first argument, and returns a string that will be used as the output bundle.
 
+* `onError` _(optional)_ is a function that takes an error as its first argument and is used to override the default handler which simply logs to `stderr`. This option is intended to be used for logging and notification purposes. Example:
+
+```js
+var colors = require('colors/safe');
+var notifier = require('node-notifier');
+var errorHandler = function(err) {
+  console.error(colors.red('Build broken. Error:'), err.message);
+  notifier.notify({ title: 'Browserify build error', message: err.message });
+b.plugin(errorify, { onError: errorHandler });
+```
+
 ### CLI
 
 After installing `errorify` as a local devDependency, you can use the `--plugin` or `-p` option like so:

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "browserify": "^11.0.1",
     "concat-stream": "^1.4.7",
     "tap": "^1.3.2",
+    "std-mocks": "^1.0.1",
     "through2": "^0.6.3"
   }
 }


### PR DESCRIPTION
Hey! Thanks for your project. I've found it to be useful.

I wanted to be able to modify the `stderr` messages that are printed to the terminal when a build has issues, and also allow for other useful things like sending a native OS notification to the developer (using `node-notifier` for example). This led me to create a hook called `onError`. It is similar to the `replacer` option.

If the user passes a function with the `onError` option, it will be called instead of the currently existing default logger. The function receives the `err` object as its only parameter.

I thought this feature might be useful as part of the main project. Let me know what you think. I've added tests and updated the README, trying to stay consistent with the rest of the project. For the tests, I used [std-mocks](https://github.com/neoziro/std-mocks) to capture stderr output and assert against it.

 I'll be happy to make any adjustments if needed.

Cheers,
Daniel
